### PR TITLE
Adds to wait starting postgresql

### DIFF
--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -12,6 +12,15 @@ echo Prepare database
 cd ${WORKSPACE}
 if [ "${DATABASE}" = "postgresql" ]; then
   service postgresql start
+  count=0
+  until sudo -u postgres psql -U "postgres" -c '\q'; do
+    if [ ${count} -eq 10 ]; then
+      echo "Failed to start postgresql."
+      exit 1
+    fi
+    count=$((count + 1))
+    sleep 1
+  done
   cp config/database.yml.postgresql config/database.yml
 elif [ "${DATABASE}" = "mysql" ]; then
   service mysql start

--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -14,7 +14,7 @@ if [ "${DATABASE}" = "postgresql" ]; then
   service postgresql start
   count=0
   until sudo -u postgres psql -U "postgres" -c '\q'; do
-    if [ ${count} -eq 10 ]; then
+    if [ ${count} -eq 60 ]; then
       echo "Failed to start postgresql."
       exit 1
     fi


### PR DESCRIPTION
Sometimes this action fails with postgresql like following log: 
https://github.com/two-pack/redmine_auto_assign_group/runs/815781616?check_suite_focus=true

~~~
Prepare database
+ cd /var/lib/redmine
+ '[' postgresql = postgresql ']'
+ service postgresql start
[....] Starting PostgreSQL 9.6 database server: main25l[ ok 12l25h.
+ cp config/database.yml.postgresql config/database.yml
+ echo Check environment
Check environment
+ google-chrome --version
Google Chrome 81.0.4044.92 
+ chromedriver --version
ChromeDriver 81.0.4044.69 (6813546031a4bc83f717a2ef7cd4ac6ec1199132-refs/branch-heads/4044@{#776})
+ RAILS_ENV=test
+ bin/about

Traceback (most recent call last):
	17: from bin/about:6:in `<main>'
	16: from /var/lib/redmine/lib/redmine/info.rb:16:in `environment'
	15: from /var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.4.2/lib/active_record/connection_handling.rb:90:in `connection'
	14: from /var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.4.2/lib/active_record/connection_handling.rb:118:in `retrieve_connection'
	13: from /var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.4.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:1033:in `retrieve_connection'
	12: from /var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.4.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:382:in `connection'
	11: from /var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.4.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:538:in `checkout'
	10: from /var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.4.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:814:in `acquire_connection'
	 9: from /var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.4.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:853:in `try_to_checkout_new_connection'
	 8: from /var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.4.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:874:in `checkout_new_connection'
	 7: from /var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.4.2/lib/active_record/connection_adapters/abstract/connection_pool.rb:830:in `new_connection'
	 6: from /var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.4.2/lib/active_record/connection_adapters/postgresql_adapter.rb:48:in `postgresql_connection'
	 5: from /var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.4.2/lib/active_record/connection_adapters/postgresql_adapter.rb:48:in `new'
	 4: from /var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.4.2/lib/active_record/connection_adapters/postgresql_adapter.rb:223:in `initialize'
	 3: from /var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/activerecord-5.2.4.2/lib/active_record/connection_adapters/postgresql_adapter.rb:692:in `connect'
	 2: from /var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/pg-1.1.4/lib/pg.rb:56:in `connect'
	 1: from /var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/pg-1.1.4/lib/pg.rb:56:in `new'
/var/lib/redmine/vendor/bundle/ruby/2.5.0/gems/pg-1.1.4/lib/pg.rb:56:in `initialize': FATAL:  the database system is starting up (PG::ConnectionBad)
FATAL:  the database system is starting up
::error::The process '/home/runner/work/_actions/two-pack/redmine-plugin-test-action/v2/lib/redmine-plugin-test.sh' failed with exit code 1
~~~

I researched and find [this](https://docs.docker.com/compose/startup-order/), and add to wait starting postgresql for 2min.

