### PR TITLE
Removes outputs from action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,6 @@ inputs:
     required: true
   database:
     description: 'The database of Redmine to test.'
-outputs:
 runs:
   using: 'node12'
   main: 'lib/redmine-plugin-test.js'


### PR DESCRIPTION
GitHub action occurs like following error because action.yml has empty output element.
```
System.ArgumentException: Unexpected type 'NullToken' encountered while reading 'outputs'. The type 'MappingToken' was expected.
   at GitHub.DistributedTask.ObjectTemplating.Tokens.TemplateTokenExtensions.AssertMapping(TemplateToken value, String objectDescription)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
```
from [here](https://github.com/two-pack/redmine_xlsx_format_issue_exporter/actions/runs/195269227)

I remove it.
