### PR TITLE
Add Github tag support when cloning the repository

### DIFF
--- a/lib/redmine-plugin-test.sh
+++ b/lib/redmine-plugin-test.sh
@@ -6,7 +6,7 @@ REDMINE_VERSION=(${2/v/})
 RUBY_VERSION=(${3/v/})
 DATABASE=$4
 if [ "${GITHUB_HEAD_REF}" = "" ]; then
-  PLUGIN_BRANCH=$(echo ${GITHUB_REF#refs/heads/})
+  PLUGIN_BRANCH=$(echo ${GITHUB_REF#refs/*/})
 else
   PLUGIN_BRANCH=${GITHUB_HEAD_REF}
 fi


### PR DESCRIPTION
When running tests for a specific tag, the clone fails like this:

```
+ git clone -b refs/tags/v1.4.0 --depth 1 https://github.com/eXolnet/redmine_risks.git /var/lib/redmine/plugins/redmine_risks
Cloning into '/var/lib/redmine/plugins/redmine_risks'...
warning: Could not find remote branch refs/tags/v1.4.0 to clone.
fatal: Remote branch refs/tags/v1.4.0 not found in upstream origin
```

Indeed, the environment variable`GITHUB_REF` looks like this for a tag: `refs/tags/v1.4.0`. This PR update the `PLUGIN_BRANCH` to support both heads and tags.

Here some examples for various `GITHUB_REF`:
```
$ GITHUB_REF=refs/head/master && echo ${GITHUB_REF#refs/*/}
master
$ GITHUB_REF=refs/head/feature/test && echo ${GITHUB_REF#refs/*/}
feature/test
$ GITHUB_REF=refs/tags/v1.4.0 && echo ${GITHUB_REF#refs/*/}
v1.4.0
```