### PR TITLE
Use cloned repository in GITHUB_WORKSPACE when available

### DIFF
--- a/lib/entrypoint.sh
+++ b/lib/entrypoint.sh
@@ -6,6 +6,7 @@ echo Set environment variables
 set -xe
 PLUGIN_REPO=https://github.com/${GITHUB_REPOSITORY}.git
 WORKSPACE=/var/lib/redmine
+PLUGIN_WORKSPACE=/var/lib/redmine-plugin
 TRACE=--trace
 
 echo Prepare database
@@ -34,8 +35,15 @@ google-chrome --version
 chromedriver --version
 RAILS_ENV=test bin/about
 
-echo Install plguin
-git clone -b ${PLUGIN_BRANCH} --depth 1 ${PLUGIN_REPO} ${WORKSPACE}/plugins/${PLUGIN_NAME}
+echo Install plugin
+
+# If the plugin's code is already cloned in PLUGIN_WORKSPACE, we'll use it. Otherwise, we'll clone a fresh copy.
+if [ -d $PLUGIN_WORKSPACE/.git ]; then
+  ln -s $PLUGIN_WORKSPACE ${WORKSPACE}/plugins/${PLUGIN_NAME}
+else
+  git clone -b ${PLUGIN_BRANCH} --depth 1 ${PLUGIN_REPO} ${WORKSPACE}/plugins/${PLUGIN_NAME}
+fi
+
 bundle install --path vendor/bundle
 bundle exec rake redmine:plugins:migrate $TRACE
 

--- a/lib/redmine-plugin-test.sh
+++ b/lib/redmine-plugin-test.sh
@@ -5,6 +5,7 @@ PLUGIN_NAME=$1
 REDMINE_VERSION=(${2/v/})
 RUBY_VERSION=(${3/v/})
 DATABASE=$4
+
 if [ "${GITHUB_HEAD_REF}" = "" ]; then
   PLUGIN_BRANCH=$(echo ${GITHUB_REF#refs/*/})
 else
@@ -19,4 +20,5 @@ docker run -e "GITHUB_REPOSITORY=${GITHUB_REPOSITORY}" \
            -e "PLUGIN_NAME=${PLUGIN_NAME}" \
            -e "PLUGIN_BRANCH=${PLUGIN_BRANCH}" \
            -e "DATABASE=${DATABASE}" \
+           -v "${GITHUB_WORKSPACE}:/var/lib/redmine-plugin" \
            -t redmine-plugin-test


### PR DESCRIPTION
When someone uses `actions/checkout`, the plugin's code is available in `GITHUB_WORKSPACE`. This PR use it when it's available. That way, this action should be able to support branches, tags and PRs.

The logic is backward compatible.